### PR TITLE
Fix first time build clean script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .parcel-cache/
 node_modules/
 dist/
+.vs/start-tab/config
+.vs

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "ISC",
   "source": "src/index.html",
   "scripts": {
-    "clean-dist": "if exist dist\\ rmdir /s /q dist && mkdir dist",
+    "clean-dist": "(if exist dist\\ rmdir /s /q dist) && mkdir dist",
     "copy-background": "copy src\\background.js dist\\background.js",
     "copy-manifest": "copy src\\manifest.json dist\\manifest.json",
     "build": "npm run clean-dist && npm run copy-background && npm run copy-manifest && parcel build --no-content-hash --no-source-maps"


### PR DESCRIPTION
Fix an issue where the first time build fails as the `clean-dist` script requires the dist directory to already exist as the `mkdir dist` command is within the `if exist`. Fixes this by adding brackets to the intended scope of the `if exist`